### PR TITLE
Fix synonym create to upsert

### DIFF
--- a/src/SqlServer.Native.Tests/SynonymTests.ReCreate.verified.sql
+++ b/src/SqlServer.Native.Tests/SynonymTests.ReCreate.verified.sql
@@ -1,0 +1,3 @@
+-- Synonyms
+
+CREATE SYNONYM [dbo].[mySynonym1] FOR [TargetDb].[dbo].[target2]

--- a/src/SqlServer.Native.Tests/SynonymTests.cs
+++ b/src/SqlServer.Native.Tests/SynonymTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.Data.SqlClient;
 using NServiceBus.Transport.SqlServerNative;
 using VerifyXunit;
 using VerifyTests;
@@ -13,33 +12,32 @@ public class SynonymTests :
     public async Task DropAll()
     {
         var synonym = new Synonym(SqlConnection, SqlConnection.Database);
-        await CreateTable();
         await synonym.Create("mySynonym3", "target");
         await synonym.DropAll();
         await Verifier.Verify(SqlConnection)
             .SchemaSettings(tables: false);
     }
 
-    async Task CreateTable()
-    {
-        await using var command = SqlConnection.CreateCommand();
-        command.CommandText = "create table target(id int);";
-        try
-        {
-            await command.ExecuteNonQueryAsync();
-        }
-        catch (SqlException)
-        {
-        }
-    }
-
     [Fact]
     public async Task Create()
     {
         var synonym = new Synonym(SqlConnection, SqlConnection.Database);
-        await CreateTable();
+
         await synonym.DropAll();
         await synonym.Create("mySynonym1", "target");
+        await Verifier.Verify(SqlConnection)
+            .SchemaSettings(tables: false)
+            .AddScrubber(builder => builder.Replace(SqlConnection.Database, "TargetDb"));
+    }
+
+    [Fact]
+    public async Task ReCreate()
+    {
+        var synonym = new Synonym(SqlConnection, SqlConnection.Database);
+        await synonym.DropAll();
+        await synonym.Create("mySynonym1", "target");
+        await synonym.Create("mySynonym1", "target2");
+
         await Verifier.Verify(SqlConnection)
             .SchemaSettings(tables: false)
             .AddScrubber(builder => builder.Replace(SqlConnection.Database, "TargetDb"));
@@ -49,7 +47,6 @@ public class SynonymTests :
     public async Task Drop()
     {
         var synonym = new Synonym(SqlConnection, SqlConnection.Database);
-        await CreateTable();
         await synonym.DropAll();
         await synonym.Create("mySynonym1", "target");
         await synonym.Drop("mySynonym1");

--- a/src/SqlServer.Native/Synonym.cs
+++ b/src/SqlServer.Native/Synonym.cs
@@ -41,18 +41,8 @@ namespace NServiceBus.Transport.SqlServerNative
             using var command = sourceDatabase.CreateCommand();
             command.Transaction = sourceTransaction;
             command.CommandText = $@"
-if not exists (
-   select 0
-    from sys.synonyms
-    inner join sys.schemas on
-               synonyms.schema_id = schemas.schema_id
-    where synonyms.name = '{target}' and
-          schemas.name ='{sourceSchema}'
-)
-begin
-    create synonym [{sourceSchema}].[{synonym}]
-    for [{targetDatabase}].[{targetSchema}].[{target}];
-end
+    drop synonym if exists [{sourceSchema}].[{synonym}];
+    create synonym [{sourceSchema}].[{synonym}] for [{targetDatabase}].[{targetSchema}].[{target}];
 ";
             await command.ExecuteNonQueryAsync();
         }
@@ -80,19 +70,7 @@ exec sp_executesql @stmt
         {
             using var command = sourceDatabase.CreateCommand();
             command.Transaction = sourceTransaction;
-            command.CommandText = $@"
-if exists (
-  select 0
-    from sys.synonyms
-    inner join sys.schemas on
-               synonyms.schema_id = schemas.schema_id
-    where synonyms.name = '{synonym}' and
-          schemas.name ='{sourceSchema}'
-)
-begin
-    drop synonym [{sourceSchema}].[{synonym}];
-end
-";
+            command.CommandText = $"drop synonym if exists [{sourceSchema}].[{synonym}];";
             await command.ExecuteNonQueryAsync();
         }
 


### PR DESCRIPTION
#### Description

The synonym install does not update on subsequent runs of the create, it just drops out as the synonym already exist. This means the target of the synonym can't be updated. 

#### The solution

I've modified the create to do a drop synonym if already exists. 
Added a test for recreating an existing synonym

I also modified the test to remove the target table.  Synonym creation doesn't validate that target table exists so it's not required







